### PR TITLE
Update build instructions so it can build on macOS too

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ f,b,sizeof(f)    );printf("\033" "[%dA\033[%dD"
 ## Build the Obfuscated Version
 
 ```console
-$ gcc -w -o conway conway.c
+$ gcc -std=c90 -w -o conway conway.c
 $ ./conway
 ```
 


### PR DESCRIPTION
This is such a cool project!

I was trying to compile it on macOS, and I would get errors like:
```c
conway.c:2:18: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
                 x,y,cx,cy,dx,
                 ^
                 int
```

After a bit of googling I found out how to tell gcc to use an older C standard which would then build successfully on macOS too. The reason why this is needed is because by default, gcc on macOS is an alias to clang as far as I can tell:
```shell
λ ~/Desktop/ gcc -v
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

All that is needed is the `-std=c90` flag which works both for clang as well as gcc!

After doing that it builds and runs just fine for me both on linux as well as macOS.
